### PR TITLE
Move raw_info into extra hash

### DIFF
--- a/lib/omniauth/strategies/apple.rb
+++ b/lib/omniauth/strategies/apple.rb
@@ -21,10 +21,13 @@ module OmniAuth
           sub: id_info['sub'],
           email: email,
           first_name: first_name,
-          last_name: last_name,
-          extra: {
-            raw_info: id_info.merge(user_info)
-          }
+          last_name: last_name
+        }
+      end
+
+      extra do
+        {
+          raw_info: id_info.merge(user_info)
         }
       end
 


### PR DESCRIPTION
Move `raw_info` into `extra` hash. This matches more closely how other omniauth integrations provide the response hash, e.g. https://github.com/zquestz/omniauth-google-oauth2/blob/master/lib/omniauth/strategies/google_oauth2.rb#L61.